### PR TITLE
Fixed some PHP notices thrown at runtime

### DIFF
--- a/classes/options.php
+++ b/classes/options.php
@@ -225,6 +225,9 @@ class options {
 	 * @return	mixed
 	 */
 	public function getOption($option) {
+		if (!array_key_exists($option, $this->options)){
+			return false;
+		}
 		return $this->options[$option];
 	}
 }

--- a/mar.php
+++ b/mar.php
@@ -55,7 +55,7 @@ class main {
 	public function __construct() {
 		define('PHP7MAR_DIR', __DIR__);
 		define('PHP7MAR_VERSION', '0.0.1');
-		spl_autoload_register([self, 'autoloader'], true, false);
+		spl_autoload_register([$this, 'autoloader'], true, false);
 
 		//Setup command line options/switches.
 		$this->options = new options();
@@ -97,8 +97,10 @@ class main {
 	 */
 	private function run() {
 		$issues = [];
+		$totalFiles = 0;
+		$totalLines = 0;
 		$filePath = $this->scanner->getCurrentFilePath();
-		if (!$this->options->getOption('t') || in_array('syntax', $this->options->getOption('t'))) {
+		if (!$this->options->getOption('t') || in_array('syntax', $this->options->getOption('t'), true)) {
 			$checkSyntax = true;
 		} else {
 			$checkSyntax = false;
@@ -155,7 +157,7 @@ class main {
 		if (is_file($file)) {
 			require_once($file);
 		} else {
-			throw new \Exception(__CLASS__.": Class file for {$classname} not found at {$file}.");
+			throw new \Exception(__CLASS__.": Class file for {$className} not found at {$file}.");
 		}
 	}
 


### PR DESCRIPTION
Fixed the following notices:

PHP Notice:  Use of undefined constant self - assumed 'self' in ~/www-dev/php7mar/mar.php on line 58
PHP Notice:  Undefined index: r in ~/www-dev/php7mar/mar.php on line 228
PHP Notice:  Undefined index: php in ~/www-dev/php7mar/mar.php on line 228
PHP Notice:  Undefined variable: totalFiles in ~/www-dev/php7mar/mar.php on line 108
PHP Notice:  Undefined variable: totalLines in ~/www-dev/php7mar/mar.php on line 128
