### PR TITLE
Adding support for specifyng file extensions to consider as PHP files

### DIFF
--- a/classes/options.php
+++ b/classes/options.php
@@ -77,7 +77,14 @@ class options {
 				'nuance',
 				'syntax'
 			]
-		]
+		],
+    'x' => [
+      'option'  => self::OPTION_OPTIONAL,
+      'value'   => self::VALUE_REQUIRED,
+      'comment' => 'File extensions to include when scanning directory',
+      'description' => 'A comma separated list of file extensions to consider as PHP files. Defaults to "php"',
+      'example' => '-x="php,inc"'
+    ]
 	];
 
 	/**

--- a/classes/scanner.php
+++ b/classes/scanner.php
@@ -25,6 +25,13 @@ class scanner {
 	 */
 	private $files = [];
 
+  /**
+   * List of file extension to process.
+   *
+   * @var   array
+   */
+  private $extensions = ['php'];
+
 	/**
 	 * Main Constructor
 	 *
@@ -32,11 +39,16 @@ class scanner {
 	 * @param	string	Project file or folder
 	 * @return	void
 	 */
-	public function __construct($projectPath) {
+	public function __construct($projectPath, Array $extensions = null) {
 		if (empty($projectPath)) {
 			throw new \Exception(__METHOD__.": Project path given was empty.");
 		}
 		$this->projectPath = $projectPath;
+
+    if (!is_null($extensions)) {
+      $this->extensions = $extensions;
+    }
+
 		$this->recursiveScan($this->projectPath);
 		reset($this->files);
 	}
@@ -63,7 +75,8 @@ class scanner {
 			if (is_dir($path)) {
 				$this->recursiveScan($path);
 			} else {
-				if (substr($content, -4) != '.php') {
+        $fileExtension = pathinfo($content, PATHINFO_EXTENSION);
+				if (strlen($fileExtension) == 0 || !in_array($fileExtension, $this->extensions)) {
 					continue;
 				}
 				$this->files[] = $path;
@@ -100,5 +113,28 @@ class scanner {
 	public function getCurrentFilePath() {
 		return current($this->files);
 	}
+
+  /**
+   * Sets the file extensions to be considered as PHP file. Ex:
+   *
+   *  array('php', 'inc')
+   *
+   * Do NOT include the dot before the extension
+   *
+   * @access public
+   * @param array $extensions
+   */
+  public function setFileExtensions(Array $extensions) {
+    $this->extensions = $extensions;
+  }
+
+  /**
+   * Gets the list of extensions to be considered PHP files when scanning
+   *
+   * @return array File extensions to be considered as PHP files
+   */
+  public function getFileExtensions() {
+    return $this->extensions;
+  }
 }
 ?>

--- a/mar.php
+++ b/mar.php
@@ -77,7 +77,10 @@ class main {
 		}
 
 		$start = microtime(true);
-		$this->scanner = new scanner($this->projectPath);
+
+    $extensions = !empty($this->options->getOption('x')) ? explode(',', $this->options->getOption('x')) : null;
+		$this->scanner = new scanner($this->projectPath, $extensions);
+
 
 		$this->run();
 		$end = microtime(true);


### PR DESCRIPTION
I use some other file extensions for PHP files, notably .inc. I created a -x option to specify file extensions to consider PHP files. Defaults to just .php, so the default use case, commands, etc will not change.

Ex:
```
    php mar.php -f=~/mycode/ 
```

Will run looking for and processing for just ".php" files as before

```
    php mar.php -f=~/mycode/ -x="php,inc"
```

Will run looking for and processing ".php" and ".inc" files
