### PR TITLE
Fix stopping on empty files

### DIFF
--- a/mar.php
+++ b/mar.php
@@ -110,7 +110,7 @@ class main {
 			$checkSyntax = false;
 		}
 
-		while ($lines = $this->scanner->scanNextFile()) {
+		while (($lines = $this->scanner->scanNextFile()) !== false) {
 			$totalFiles++;
 
 			//Check syntax and assign a line to grab if needed.


### PR DESCRIPTION
If a file is empty, `scanNextFile` returns an empty array, which is considered false.