### PR TITLE
Markdown result changes

### DIFF
--- a/classes/reporter.php
+++ b/classes/reporter.php
@@ -137,9 +137,9 @@ class reporter {
 	 */
 	public function addSections() {
 		foreach ($this->sectionBuffers as $section => $filePaths) {
-			$this->add('#'.$section, 1, 1);
+			$this->add('# '.$section, 1, 1);
 			foreach ($filePaths as $filePath => $tests) {
-				$this->add('####'.$filePath, 0, 1);
+				$this->add('#### '.$filePath, 0, 1);
 				foreach ($tests as $test => $lines) {
 					$this->add('* '.$test, 0, 1);
 					foreach ($lines as $line) {

--- a/classes/reporter.php
+++ b/classes/reporter.php
@@ -143,7 +143,7 @@ class reporter {
 				foreach ($tests as $test => $lines) {
 					$this->add('* '.$test, 0, 1);
 					foreach ($lines as $line) {
-						$this->add(" * Line {$line[0]}: {$line[1]}", 0, 1);
+						$this->add(" * Line {$line[0]}: `" . str_replace('`', '\'', $line[1]) . "`", 0, 1);
 					}
 				}
 				$this->add('', 1, 0);


### PR DESCRIPTION
- Adds spaces between headings because some markdown parsers require that
- Add code blocks so that it doesn't fail horribly (e.g when posting results on gihub's gist)