### PR TITLE
Fixed: Missing '/' in manually set report path

### DIFF
--- a/classes/reporter.php
+++ b/classes/reporter.php
@@ -73,9 +73,9 @@ class reporter {
 		if ($reportFolder !== false) {
 			$this->reportFolder = $reportFolder;
 		} else {
-			$this->reportFolder = PHP7MAR_DIR.DIRECTORY_SEPARATOR.'reports'.DIRECTORY_SEPARATOR;
+			$this->reportFolder = PHP7MAR_DIR.DIRECTORY_SEPARATOR.'reports';
 		}
-		$this->fullFilePath = $this->reportFolder.date('Y-m-d H.i.s ').basename($this->projectPath, '.php').".md";
+		$this->fullFilePath = $this->reportFolder.DIRECTORY_SEPARATOR.date('Y-m-d H.i.s ').basename($this->projectPath, '.php').".md";
 
 		$this->file = fopen($this->fullFilePath, 'w+');
 		register_shutdown_function([$this, 'onShutdown']);


### PR DESCRIPTION
When using the '-r' option, eg `-r="/foo/bar"` the report was not saved to that location. Instead all reports were saved in `/foo` prefixed with `bar`: `Report located at: /foo/bar2015-12-08 ...`

This pull request fixes this issue.

Reports are now saved to `/foo/bar/2015-...`