### PR TITLE
Add a check for new operator with reference

### DIFF
--- a/classes/tests/critical.php
+++ b/classes/tests/critical.php
@@ -27,7 +27,8 @@ class critical {
 		'variableInterpolation',
 		'duplicateFunctionParameter',
 		'reservedNames',
-		'deprecatedFunctions'
+		'deprecatedFunctions',
+		'newOperatorWithReference',
 	];
 
 	/**
@@ -111,6 +112,22 @@ class critical {
 	 */
 	public function _deprecatedFunctions($line) {
 		$regex = "#(?:mysql_affected_rows|mysql_client_encoding|mysql_close|mysql_connect|mysql_create_db|mysql_data_seek|mysql_db_name|mysql_db_query|mysql_drop_db|mysql_errno|mysql_error|mysql_escape_string|mysql_fetch_array|mysql_fetch_assoc|mysql_fetch_field|mysql_fetch_lengths|mysql_fetch_object|mysql_fetch_row|mysql_field_flags|mysql_field_len|mysql_field_name|mysql_field_seek|mysql_field_table|mysql_field_type|mysql_free_result|mysql_get_client_info|mysql_get_host_info|mysql_get_proto_info|mysql_get_server_info|mysql_info|mysql_insert_id|mysql_list_dbs|mysql_list_fields|mysql_list_processes|mysql_list_tables|mysql_num_fields|mysql_num_rows|mysql_pconnect|mysql_ping|mysql_query|mysql_real_escape_string|mysql_result|mysql_select_db|mysql_set_charset|mysql_stat|mysql_tablename|mysql_thread_id|mysql_unbuffered_query|mcrypt_generic_end|mcrypt_ecb|mcrypt_cbc|mcrypt_cfb|mcrypt_ofb|set_magic_quotes_runtime|magic_quotes_runtime|set_socket_blocking)\(#i";
+		if (preg_match($regex, $line)) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * New objects cannot be assigned by reference
+	 *
+	 * @access	public
+	 * @param	string	Line to test against.
+	 * @return	boolean	Line matches test.
+	 */
+	public function _newOperatorWithReference($line) {
+		$regex = "#&\s?new\s#";
+
 		if (preg_match($regex, $line)) {
 			return true;
 		}

--- a/testcases.php
+++ b/testcases.php
@@ -122,4 +122,8 @@ mysql_stat();
 mysql_tablename();
 mysql_thread_id();
 mysql_unbuffered_query();
-?>
+
+// New objects cannot be assigned by reference
+class C {}
+$c =& new C;
+$c =&new C;


### PR DESCRIPTION
http://php.net/manual/en/migration70.incompatible.php#migration70.incompatible.other.new-by-ref

Add a check for the following use of `new` operator which is no longer supported:

```php
<?php
class C {}
$c =& new C;
?>
```

`Parse error: syntax error, unexpected 'new' (T_NEW) in /tmp/test.php on line 3`

This code will generate the following entry in the report:

```md
* newOperatorWithReference
 * Line 123: `$c =& new C;`
 * Line 124: `$c =&new C;`
```