### PR TITLE
PHP4 style constructors are deprecated in PHP7

### DIFF
--- a/classes/tests/critical.php
+++ b/classes/tests/critical.php
@@ -29,6 +29,7 @@ class critical {
 		'reservedNames',
 		'deprecatedFunctions',
 		'newOperatorWithReference',
+		'oldClassConstructors',
 	];
 
 	/**
@@ -131,6 +132,31 @@ class critical {
 		if (preg_match($regex, $line)) {
 			return true;
 		}
+		return false;
+	}
+
+	public function _oldClassConstructors($line) {
+		static $lastClassName = false;
+
+		// reset the name of the class that we've seen
+		if ($line === '<?php') {
+			$lastClassName = false;
+		}
+
+		// find the start of PHP class declaration
+		if (strpos($line, 'class') === 0) {
+			if (preg_match('#class (\w+)#', $line, $matches)) {
+				$lastClassName = $matches[1];
+			}
+		}
+
+		// is the class name used as the function name?
+		if ($lastClassName !== false && strpos($line, 'function') !== false) {
+			if (preg_match("#function {$lastClassName}\s?\(#", $line)) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 }

--- a/testcases.php
+++ b/testcases.php
@@ -127,3 +127,14 @@ mysql_unbuffered_query();
 class C {}
 $c =& new C;
 $c =&new C;
+
+// Methods with the same name as their class will not be constructors in a future version of PHP
+class FooBar {
+	var $test = 42;
+
+	function set() {}
+
+	function FooBar() {
+		// NOP
+	}
+}


### PR DESCRIPTION
[PHP 4 style constructors](http://php.net/manual/en/migration70.deprecated.php):

> PHP 4 style constructors (methods that have the same name as the class they are defined in) are deprecated, and will be removed in the future. PHP 7 will emit `E_DEPRECATED` if a PHP 4 constructor is the only constructor defined within a class. Classes that implement a `__construct() `method are unaffected.

```php
// Methods with the same name as their class will not be constructors in a future version of PHP
class FooBar {
        var $test = 42;

        function set() {}

        function FooBar() {
                // NOP
        }
}
```

will be reported as follows:

```md
* oldClassConstructors
 * Line 129: `  function FooBar() {`
```

and PHP7 will complain:

`Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP`