### PR TITLE
Replace blank spaces of file name

### DIFF
--- a/classes/reporter.php
+++ b/classes/reporter.php
@@ -75,7 +75,7 @@ class reporter {
 		} else {
 			$this->reportFolder = PHP7MAR_DIR.DIRECTORY_SEPARATOR.'reports';
 		}
-		$this->fullFilePath = $this->reportFolder.DIRECTORY_SEPARATOR.date('Y-m-d H.i.s ').basename($this->projectPath, '.php').".md";
+		$this->fullFilePath = $this->reportFolder.DIRECTORY_SEPARATOR.date('Y-m-d_H.i.s_').basename($this->projectPath, '.php').".md";
 
 		$this->file = fopen($this->fullFilePath, 'w+');
 		register_shutdown_function([$this, 'onShutdown']);


### PR DESCRIPTION
Replace the blank spaces of the generated file name, which make them more easy to manipulate on Linux.